### PR TITLE
Fix minor typo in execpolicy comment

### DIFF
--- a/codex-rs/execpolicy/src/opt.rs
+++ b/codex-rs/execpolicy/src/opt.rs
@@ -59,7 +59,7 @@ impl<'v> UnpackValue<'v> for Opt {
     type Error = starlark::Error;
 
     fn unpack_value_impl(value: Value<'v>) -> starlark::Result<Option<Self>> {
-        // TODO(mbolin): It fels like this should be doable without cloning?
+        // TODO(mbolin): It feels like this should be doable without cloning?
         // Cannot simply consume the value?
         Ok(value.downcast_ref::<Opt>().cloned())
     }


### PR DESCRIPTION
## Summary
- fix spelling in execpolicy opt.rs comment

## Testing
- `cargo test -p codex-execpolicy`

------
https://chatgpt.com/codex/tasks/task_b_68491b9af9b883318c7ac734dcc7118f (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
diff --git a/codex-rs/execpolicy/src/opt.rs b/codex-rs/execpolicy/src/opt.rs
index 2325d9980473c7fab0b6435873eb30de10ae33e1..348e542bec407e5ddfbbfeaa16999dc1b650dbaa 100644
--- a/codex-rs/execpolicy/src/opt.rs
+++ b/codex-rs/execpolicy/src/opt.rs
@@ -37,41 +37,41 @@ pub enum OptMeta {
 }
 
 impl Opt {
     pub fn new(opt: String, meta: OptMeta, required: bool) -> Self {
         Self {
             opt,
             meta,
             required,
         }
     }
 
     pub fn name(&self) -> &str {
         &self.opt
     }
 }
 
 #[starlark_value(type = "Opt")]
 impl<'v> StarlarkValue<'v> for Opt {
     type Canonical = Opt;
 }
 
 impl<'v> UnpackValue<'v> for Opt {
     type Error = starlark::Error;
 
     fn unpack_value_impl(value: Value<'v>) -> starlark::Result<Option<Self>> {
-        // TODO(mbolin): It fels like this should be doable without cloning?
+        // TODO(mbolin): It feels like this should be doable without cloning?
         // Cannot simply consume the value?
         Ok(value.downcast_ref::<Opt>().cloned())
     }
 }
 
 impl<'v> AllocValue<'v> for Opt {
     fn alloc_value(self, heap: &'v Heap) -> Value<'v> {
         heap.alloc_simple(self)
     }
 }
 
 #[starlark_value(type = "OptMeta")]
 impl<'v> StarlarkValue<'v> for OptMeta {
     type Canonical = OptMeta;
 }
 
EOF
)

