### PR TITLE
Fix minor typo in execpolicy comment

### DIFF
--- a/codex-rs/execpolicy/src/opt.rs
+++ b/codex-rs/execpolicy/src/opt.rs
@@ -59,7 +59,7 @@ impl<'v> UnpackValue<'v> for Opt {
     type Error = starlark::Error;
 
     fn unpack_value_impl(value: Value<'v>) -> starlark::Result<Option<Self>> {
-        // TODO(mbolin): It fels like this should be doable without cloning?
+        // TODO(mbolin): It feels like this should be doable without cloning?
         // Cannot simply consume the value?
         Ok(value.downcast_ref::<Opt>().cloned())
     }


### PR DESCRIPTION
## Summary
- fix spelling in execpolicy opt.rs comment

## Testing
- `cargo test -p codex-execpolicy`

------
https://chatgpt.com/codex/tasks/task_b_68491b9af9b883318c7ac734dcc7118f