### PR TITLE
Update sandbox docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,23 @@ The hardening mechanism Codex uses depends on your OS:
     tries to `curl` somewhere it will fail.
 
 - **Linux** - there is no sandboxing by default.
-  We recommend using Docker for sandboxing, where Codex launches itself inside a **minimal
-  container image** and mounts your repo _read/write_ at the same path. A
-  custom `iptables`/`ipset` firewall script denies all egress except the
-  OpenAI API. This gives you deterministic, reproducible runs without needing
-  root on the host. You can use the [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set up the sandbox.
+  We recommend using Docker for sandboxing, where Codex launches itself inside a
+  **minimal container image** and mounts your repo _read/write_ at the same
+  path. A custom `iptables`/`ipset` firewall script denies all egress except the
+  OpenAI API. Use the
+  [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) script to set
+  up the sandbox and get deterministic runs without needing root on the host.
+
+  This script reads the `OPENAI_ALLOWED_DOMAINS` environment variable to control outbound
+  access. When unset, it defaults to `api.openai.com`. Provide additional domains as a
+  space-separated list:
+
+  ```bash
+  OPENAI_ALLOWED_DOMAINS="api.openai.com example.com" ./codex-cli/scripts/run_in_container.sh "your command"
+  ```
+
+  See [`run_in_container.sh`](./codex-cli/scripts/run_in_container.sh) for more
+  advanced options.
 
 ---
 

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -10,7 +10,9 @@ set -e
 
 # Default the work directory to WORKSPACE_ROOT_DIR if not provided.
 WORK_DIR="${WORKSPACE_ROOT_DIR:-$(pwd)}"
-# Default allowed domains - can be overridden with OPENAI_ALLOWED_DOMAINS env var
+# Default allowed domains. When OPENAI_ALLOWED_DOMAINS is unset, only
+# `api.openai.com` is allowed. Provide a space-separated list to allow more.
+# See README for details and additional options.
 OPENAI_ALLOWED_DOMAINS="${OPENAI_ALLOWED_DOMAINS:-api.openai.com}"
 
 # Parse optional flag.


### PR DESCRIPTION
## Summary
- clarify OPENAI_ALLOWED_DOMAINS usage in the Linux sandbox docs
- note default in `run_in_container.sh`

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_b_6848a86774f88331925271d16349f039